### PR TITLE
chore: relax npm engine strictness for Forge deployments

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=false
+fund=false


### PR DESCRIPTION
### Motivation
- Prevent deploy failures on Laravel Forge where optional dependencies declare newer Node engine requirements (e.g. Node >= 20) that can block installs when npm enforces engine strictness, and reduce noisy funding messages in deploy logs.

### Description
- Add a project-level `.npmrc` containing `engine-strict=false` and `fund=false` to disable strict engine checks and suppress funding notices.

### Testing
- Verified `npm config get engine-strict` returned `false` and `npm config get fund` returned `false`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7977872ec8327966300f042734d0f)