### PR TITLE
Pin Tailwind packages, remove unused deps, and add .npmrc for install behavior

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+engine-strict=false
+fund=false
+include=optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,11 @@
             "name": "index",
             "version": "0.1.0",
             "dependencies": {
-                "@tailwindcss/vite": "^4.0.7",
-                "autoprefixer": "^10.4.20",
-                "axios": "^1.7.4",
+                "@tailwindcss/vite": "4.2.1",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^1.0",
-                "tailwindcss": "^4.0.7",
+                "tailwindcss": "4.2.1",
                 "vite": "^6.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-linux-x64-gnu": "4.9.5",
-                "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
-                "lightningcss-linux-x64-gnu": "^1.29.1"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -8,17 +8,10 @@
         "dev": "vite"
     },
     "dependencies": {
-        "@tailwindcss/vite": "^4.0.7",
-        "autoprefixer": "^10.4.20",
-        "axios": "^1.7.4",
+        "@tailwindcss/vite": "4.2.1",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.0",
-        "tailwindcss": "^4.0.7",
+        "tailwindcss": "4.2.1",
         "vite": "^6.0"
-    },
-    "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.9.5",
-        "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
-        "lightningcss-linux-x64-gnu": "^1.29.1"
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure deterministic Tailwind tooling versions and simplify the dependency surface by removing unused packages and stale optional entries.
- Control npm install behavior and suppress funding/engine strict checks via repository `.npmrc` to avoid install interruptions in CI or diverse environments.

### Description
- Add `.npmrc` with `engine-strict=false`, `fund=false`, and `include=optional` to adjust install behavior.
- Update `package.json` to pin `@tailwindcss/vite` and `tailwindcss` to `4.2.1` and remove `autoprefixer`, `axios`, and the `optionalDependencies` block.
- Regenerate `package-lock.json` to reflect the pinned versions and the removal of optional dependency entries.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7977872ec8327966300f042734d0f)