### PR TITLE
Add first-run installer and site-branding settings for self-hosted deployment

### DIFF
--- a/app/Http/Controllers/InstallerController.php
+++ b/app/Http/Controllers/InstallerController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Support\SiteSettings;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+
+class InstallerController extends Controller
+{
+    public function __construct(private readonly SiteSettings $siteSettings) {}
+
+    public function show(): View|RedirectResponse
+    {
+        if ($this->siteSettings->isInstalled()) {
+            return redirect()->route('home');
+        }
+
+        return view('install.show', [
+            'defaults' => $this->siteSettings->all(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        if ($this->siteSettings->isInstalled()) {
+            return redirect()->route('home');
+        }
+
+        $validated = $request->validate([
+            'site_name' => ['required', 'string', 'max:120'],
+            'site_url' => ['required', 'url', 'max:255'],
+            'scanner_title' => ['required', 'string', 'max:160'],
+            'scanner_tagline' => ['nullable', 'string', 'max:500'],
+            'label_name' => ['required', 'string', 'max:120'],
+            'label_tagline' => ['nullable', 'string', 'max:500'],
+            'logo' => ['nullable', 'image', 'max:4096'],
+        ]);
+
+        $logoPath = null;
+
+        if ($request->hasFile('logo')) {
+            $extension = $request->file('logo')->getClientOriginalExtension() ?: 'png';
+            $logoPath = $request->file('logo')->storeAs(
+                'branding',
+                'site-logo-'.Str::uuid().'.'.$extension,
+                'public',
+            );
+        }
+
+        $this->siteSettings->install([
+            'site_name' => $validated['site_name'],
+            'site_url' => $validated['site_url'],
+            'scanner_title' => $validated['scanner_title'],
+            'scanner_tagline' => $validated['scanner_tagline'] ?? null,
+            'label_name' => $validated['label_name'],
+            'label_tagline' => $validated['label_tagline'] ?? null,
+            'logo_path' => $logoPath,
+        ]);
+
+        return redirect()
+            ->route('home')
+            ->with('status', 'Installation complete. Your self-hosted scanner is ready.');
+    }
+}

--- a/app/Http/Middleware/EnsureApplicationInstalled.php
+++ b/app/Http/Middleware/EnsureApplicationInstalled.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Support\SiteSettings;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureApplicationInstalled
+{
+    public function __construct(private readonly SiteSettings $siteSettings) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($this->siteSettings->isInstalled() || $request->routeIs('install.*')) {
+            return $next($request);
+        }
+
+        return redirect()->route('install.show');
+    }
+}

--- a/app/Models/AppSetting.php
+++ b/app/Models/AppSetting.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AppSetting extends Model
+{
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    protected $primaryKey = 'key';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Support\SiteSettings;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Auth0\Laravel\Events\AuthenticationFailed;
 
@@ -14,16 +16,29 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(SiteSettings::class);
     }
 
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void
+    public function boot(SiteSettings $siteSettings): void
     {
+        $settings = $siteSettings->all();
+
+        config([
+            'app.name' => $settings['site_name'],
+            'app.url' => $settings['site_url'],
+        ]);
+
+        View::share('siteSettings', $settings);
+
         // Force HTTPS locally if APP_URL uses https:// to keep cookie/session consistent
         $appUrl = config('app.url');
+        if (is_string($appUrl) && $appUrl !== '') {
+            URL::forceRootUrl($appUrl);
+        }
+
         if (is_string($appUrl) && str_starts_with($appUrl, 'https://')) {
             URL::forceScheme('https');
         }

--- a/app/Support/SiteSettings.php
+++ b/app/Support/SiteSettings.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\AppSetting;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class SiteSettings
+{
+    private ?array $settings = null;
+
+    public function all(): array
+    {
+        if ($this->settings !== null) {
+            return $this->settings;
+        }
+
+        if (! Schema::hasTable('app_settings')) {
+            return $this->settings = $this->defaults();
+        }
+
+        $stored = AppSetting::query()
+            ->pluck('value', 'key')
+            ->all();
+
+        $settings = array_merge($this->defaults(), $stored);
+        $settings['installed'] = filled($settings['installed_at'] ?? null);
+        $settings['site_url'] = $this->normalizeUrl($settings['site_url'] ?? null) ?? config('app.url');
+        $settings['logo_url'] = $this->logoUrl($settings['logo_path'] ?? null);
+
+        return $this->settings = $settings;
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->all()[$key] ?? $default;
+    }
+
+    public function isInstalled(): bool
+    {
+        return (bool) ($this->all()['installed'] ?? false);
+    }
+
+    public function install(array $settings): void
+    {
+        $payload = array_merge($this->defaults(), $settings, [
+            'installed_at' => $settings['installed_at'] ?? now()->toIso8601String(),
+        ]);
+
+        $payload['site_url'] = $this->normalizeUrl($payload['site_url']) ?? config('app.url');
+        $rows = [];
+
+        foreach ($payload as $key => $value) {
+            if ($key === 'installed' || $key === 'logo_url') {
+                continue;
+            }
+
+            $rows[] = [
+                'key' => $key,
+                'value' => $value,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+        }
+
+        DB::transaction(function () use ($rows): void {
+            AppSetting::query()->upsert($rows, ['key'], ['value', 'updated_at']);
+        });
+
+        $this->settings = null;
+    }
+
+    public function logoUrl(?string $path = null): string
+    {
+        $path ??= $this->get('logo_path');
+
+        return $path
+            ? asset('storage/'.$path)
+            : asset('index-h.svg');
+    }
+
+    private function defaults(): array
+    {
+        return [
+            'installed' => false,
+            'installed_at' => null,
+            'site_name' => config('app.name', 'Index'),
+            'site_url' => config('app.url'),
+            'logo_path' => null,
+            'scanner_title' => 'One trusted source.',
+            'scanner_tagline' => 'Scan an item UUID, post photos from camera, and keep the canonical timeline in one place.',
+            'label_name' => 'Asset Label',
+            'label_tagline' => 'Scan to access the canonical item record and timeline.',
+        ];
+    }
+
+    private function normalizeUrl(?string $url): ?string
+    {
+        if (! is_string($url) || $url === '') {
+            return null;
+        }
+
+        return rtrim($url, '/');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,10 @@ return Application::configure(basePath: dirname(__DIR__))
         Auth0ServiceProvider::class,
     ])
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->appendToGroup('web', [
+            \App\Http\Middleware\EnsureApplicationInstalled::class,
+        ]);
+
         $middleware->alias([
             'auth0.verified' => \App\Http\Middleware\EnsureVerifiedEmail::class,
             'verified.email' => \App\Http\Middleware\EnsureVerifiedEmail::class,

--- a/database/migrations/2026_03_23_000000_create_app_settings_table.php
+++ b/database/migrations/2026_03_23_000000_create_app_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('app_settings', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->longText('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('app_settings');
+    }
+};

--- a/resources/views/components/app-logo-icon.blade.php
+++ b/resources/views/components/app-logo-icon.blade.php
@@ -1,1 +1,1 @@
-<img src="{{ asset('index-h.svg') }}" alt="{{ config('app.name') }}" {{ $attributes->class('logo-adaptive') }}>
+<img src="{{ app(\App\Support\SiteSettings::class)->logoUrl() }}" alt="{{ config('app.name') }}" {{ $attributes->class('logo-adaptive') }}>

--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -1,4 +1,4 @@
 <div class="flex items-center gap-2">
     <x-app-logo-icon class="h-7 w-auto" />
-    <span class="text-sm font-semibold uppercase tracking-[0.16em]">Index</span>
+    <span class="text-sm font-semibold uppercase tracking-[0.16em]">{{ config('app.name') }}</span>
 </div>

--- a/resources/views/install/show.blade.php
+++ b/resources/views/install/show.blade.php
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    @include('partials.head', ['title' => 'Install '.config('app.name')])
+</head>
+<body>
+    <main class="terminal-shell py-10 text-sm">
+        <section class="terminal-panel mx-auto w-full max-w-4xl">
+            <p class="terminal-accent">FIRST RUN INSTALLER</p>
+            <h1 class="terminal-title mt-2">Configure your self-hosted scanner</h1>
+            <p class="terminal-muted mt-3 max-w-2xl">
+                Productize this instance by choosing the public site URL, uploading a logo, and defining the copy shown on scanner pages and printed labels.
+            </p>
+
+            @if ($errors->any())
+                <div class="mt-4 border border-rose-500 bg-rose-950 p-3 text-rose-200">
+                    <p class="font-semibold">Please fix the highlighted fields.</p>
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('install.store') }}" enctype="multipart/form-data" class="mt-6 grid gap-6 md:grid-cols-2">
+                @csrf
+
+                <label class="grid gap-2 md:col-span-1">
+                    <span class="terminal-accent">Site name</span>
+                    <input type="text" name="site_name" value="{{ old('site_name', $defaults['site_name']) }}" required class="terminal-field">
+                    @error('site_name')<span class="text-rose-400">{{ $message }}</span>@enderror
+                </label>
+
+                <label class="grid gap-2 md:col-span-1">
+                    <span class="terminal-accent">Public site URL</span>
+                    <input type="url" name="site_url" value="{{ old('site_url', $defaults['site_url']) }}" required class="terminal-field" placeholder="https://scanner.example.com">
+                    @error('site_url')<span class="text-rose-400">{{ $message }}</span>@enderror
+                </label>
+
+                <label class="grid gap-2 md:col-span-1">
+                    <span class="terminal-accent">Scanner headline</span>
+                    <input type="text" name="scanner_title" value="{{ old('scanner_title', $defaults['scanner_title']) }}" required class="terminal-field">
+                    @error('scanner_title')<span class="text-rose-400">{{ $message }}</span>@enderror
+                </label>
+
+                <label class="grid gap-2 md:col-span-1">
+                    <span class="terminal-accent">Printed label name</span>
+                    <input type="text" name="label_name" value="{{ old('label_name', $defaults['label_name']) }}" required class="terminal-field">
+                    @error('label_name')<span class="text-rose-400">{{ $message }}</span>@enderror
+                </label>
+
+                <label class="grid gap-2 md:col-span-2">
+                    <span class="terminal-accent">Scanner description</span>
+                    <textarea name="scanner_tagline" rows="3" class="terminal-field">{{ old('scanner_tagline', $defaults['scanner_tagline']) }}</textarea>
+                    @error('scanner_tagline')<span class="text-rose-400">{{ $message }}</span>@enderror
+                </label>
+
+                <label class="grid gap-2 md:col-span-2">
+                    <span class="terminal-accent">Printed label footer</span>
+                    <textarea name="label_tagline" rows="3" class="terminal-field">{{ old('label_tagline', $defaults['label_tagline']) }}</textarea>
+                    @error('label_tagline')<span class="text-rose-400">{{ $message }}</span>@enderror
+                </label>
+
+                <label class="grid gap-2 md:col-span-2">
+                    <span class="terminal-accent">Brand logo</span>
+                    <input type="file" name="logo" accept="image/*" class="terminal-field">
+                    <span class="terminal-muted text-xs">PNG, JPG, WebP, or SVG-compatible image up to 4 MB. If omitted, the default logo is kept.</span>
+                    @error('logo')<span class="text-rose-400">{{ $message }}</span>@enderror
+                </label>
+
+                <div class="md:col-span-2 flex flex-wrap gap-3">
+                    <button type="submit" class="terminal-btn terminal-btn-accent">Complete Installation</button>
+                    <span class="terminal-muted self-center">You can revisit branding later by editing the stored app settings.</span>
+                </div>
+            </form>
+        </section>
+    </main>
+</body>
+</html>

--- a/resources/views/items/missing-guest.blade.php
+++ b/resources/views/items/missing-guest.blade.php
@@ -12,7 +12,7 @@
         <section class="terminal-panel max-w-3xl">
             <p class="terminal-accent">[SCAN TARGET: {{ $uuid }}]</p>
             <h1 class="terminal-title mt-2">Object Not Initialized</h1>
-            <p class="terminal-muted mt-3">This UUID is unclaimed. Log in to initialize this object.</p>
+            <p class="terminal-muted mt-3">This UUID is unclaimed. {{ $siteSettings['scanner_tagline'] }}</p>
             <a href="/login" class="terminal-btn terminal-btn-accent mt-4">Login With Auth0</a>
         </section>
     </main>

--- a/resources/views/items/print.blade.php
+++ b/resources/views/items/print.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Print Label - {{ $item->uuid }}</title>
+    <title>{{ $siteSettings['label_name'] }} - {{ $item->uuid }}</title>
     <style>
         body {
             margin: 0;
@@ -108,18 +108,19 @@
     <div class="label">
         <div class="top">
             <div class="logo-wrap">
-                <img src="{{ asset('index-triangle-red.png') }}" alt="Index triangle logo" class="logo">
+                <img src="{{ app(\App\Support\SiteSettings::class)->logoUrl() }}" alt="{{ config('app.name') }} logo" class="logo">
             </div>
             <div class="qr">{!! $qrSvg !!}</div>
         </div>
 
         <div class="meta">
             <h1>{{ $item->name }}</h1>
+            <div class="uuid">{{ $siteSettings['label_name'] }}</div>
             <div class="uuid">UUID: {{ $item->uuid }}</div>
         </div>
 
         <div class="flavor">
-            {{ $item->description ?: 'One trusted source. Scan to access the canonical item record and timeline.' }}
+            {{ $item->description ?: $siteSettings['label_tagline'] }}
         </div>
     </div>
 </body>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,19 +1,23 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
-        @include('partials.head', ['title' => 'index'])
+        @include('partials.head', ['title' => config('app.name')])
     </head>
     <body>
         <main class="terminal-shell flex min-h-screen items-center">
             <section class="terminal-panel w-full">
                 <div class="flex flex-wrap items-center justify-between gap-3">
-                    <img src="{{ asset('index-v.svg') }}" alt="index" class="logo-adaptive h-16 w-auto">
+                    <img src="{{ app(\App\Support\SiteSettings::class)->logoUrl() }}" alt="{{ config('app.name') }}" class="logo-adaptive h-16 w-auto">
                     <button type="button" data-theme-toggle class="terminal-btn terminal-btn-accent text-xs">Switch to Dark</button>
                 </div>
 
-                <h1 class="terminal-title mt-6">One trusted source.</h1>
+                @if (session('status'))
+                    <p class="mt-6 border border-emerald-500 bg-emerald-950 p-3 text-emerald-300">{{ session('status') }}</p>
+                @endif
+
+                <h1 class="terminal-title mt-6">{{ $siteSettings['scanner_title'] }}</h1>
                 <p class="terminal-muted mt-3 max-w-2xl">
-                    Scan an item UUID, post photos from camera, and keep the canonical timeline in one place.
+                    {{ $siteSettings['scanner_tagline'] }}
                 </p>
 
                 <div class="mt-6 flex flex-wrap gap-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,14 @@
 <?php
 
+use App\Http\Controllers\InstallerController;
 use App\Http\Controllers\ItemController;
 use App\Models\Item;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
+
+
+Route::get('install', [InstallerController::class, 'show'])->name('install.show');
+Route::post('install', [InstallerController::class, 'store'])->name('install.store');
 
 Route::get('/', function () {
     return view('welcome');

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -5,6 +5,10 @@ use Livewire\Volt\Volt as LivewireVolt;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('login screen can be rendered', function () {
     $response = $this->get('/login');
 

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Facades\URL;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('email verification screen can be rendered', function () {
     $user = User::factory()->unverified()->create();
 

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -5,6 +5,10 @@ use Livewire\Volt\Volt;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('confirm password screen can be rendered', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -7,6 +7,10 @@ use Livewire\Volt\Volt;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('reset password link screen can be rendered', function () {
     $response = $this->get('/forgot-password');
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -4,6 +4,10 @@ use Livewire\Volt\Volt;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('registration screen can be rendered', function () {
     $response = $this->get('/register');
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -4,6 +4,10 @@ use App\Models\User;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('guests are redirected to the login page', function () {
     $response = $this->get('/dashboard');
     $response->assertRedirect('/login');

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,5 +1,11 @@
 <?php
 
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    installApplication();
+});
+
 it('returns a successful response', function () {
     $response = $this->get('/');
 

--- a/tests/Feature/InstallerTest.php
+++ b/tests/Feature/InstallerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\AppSetting;
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+test('first run requests are redirected to the installer', function () {
+    $response = $this->get('/');
+
+    $response->assertRedirect(route('install.show'));
+});
+
+test('installer stores branding settings and applies them to scanner pages and labels', function () {
+    Storage::fake('public');
+
+    $response = $this->post(route('install.store'), [
+        'site_name' => 'Warehouse Scanner',
+        'site_url' => 'https://scanner.example.com/',
+        'scanner_title' => 'Scan with confidence.',
+        'scanner_tagline' => 'Track equipment, intake photos, and hand off labels with your own brand.',
+        'label_name' => 'Warehouse Label',
+        'label_tagline' => 'Scan for the canonical warehouse record.',
+        'logo' => UploadedFile::fake()->image('brand.png', 200, 80),
+    ]);
+
+    $response->assertRedirect(route('home'));
+    expect(AppSetting::query()->where('key', 'installed_at')->exists())->toBeTrue();
+    expect(AppSetting::query()->where('key', 'site_url')->value('value'))->toBe('https://scanner.example.com');
+
+    $home = $this->get('/');
+    $home->assertOk();
+    $home->assertSee('Warehouse Scanner');
+    $home->assertSee('Scan with confidence.');
+
+    $user = User::factory()->create();
+    $item = Item::factory()->for($user)->create([
+        'description' => null,
+    ]);
+
+    $label = $this->actingAs($user)->get(route('items.print', ['uuid' => $item->uuid]));
+    $label->assertOk();
+    $label->assertSee('Warehouse Label');
+    $label->assertSee('Scan for the canonical warehouse record.');
+
+    Storage::disk('public')->assertExists(AppSetting::query()->where('key', 'logo_path')->value('value'));
+});

--- a/tests/Feature/ItemFlowTest.php
+++ b/tests/Feature/ItemFlowTest.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Str;
 
 uses(RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('guest sees login prompt for unknown uuid', function () {
     $uuid = (string) Str::uuid();
 

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -6,6 +6,10 @@ use Livewire\Volt\Volt;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('password can be updated', function () {
     $user = User::factory()->create([
         'password' => Hash::make('password'),

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -5,6 +5,10 @@ use Livewire\Volt\Volt;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+beforeEach(function () {
+    installApplication();
+});
+
 test('profile page is displayed', function () {
     $this->actingAs($user = User::factory()->create());
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,3 +45,16 @@ function something()
 {
     // ..
 }
+
+
+function installApplication(array $overrides = []): void
+{
+    app(\App\Support\SiteSettings::class)->install(array_merge([
+        'site_name' => 'Index',
+        'site_url' => 'https://index.test',
+        'scanner_title' => 'One trusted source.',
+        'scanner_tagline' => 'Scan an item UUID, post photos from camera, and keep the canonical timeline in one place.',
+        'label_name' => 'Asset Label',
+        'label_tagline' => 'Scan to access the canonical item record and timeline.',
+    ], $overrides));
+}


### PR DESCRIPTION
### Motivation
- Provide a WordPress-like first-run installer so a self-hosted instance can be productized by configuring the public site URL, brand logo, scanner copy, and printed label copy.
- Prevent the app from serving public pages until basic branding and the site URL are stored, and ensure the runtime app identity (name/URL) reflects installed settings.

### Description
- Add persistent settings storage via a new `app_settings` table and `AppSetting` model plus a `SiteSettings` service that exposes `all()`, `get()`, `install()` and `logoUrl()` helpers.
- Implement an `InstallerController` with `show` and `store` actions and a simple installation Blade view at `GET /install` and `POST /install`, including logo upload handling to the `public` disk.
- Add `EnsureApplicationInstalled` middleware and append it to the `web` middleware group so uninstalled apps are redirected to the installer; wire `SiteSettings` as a singleton in `AppServiceProvider` and apply saved `site_name`/`site_url` at boot with `View::share('siteSettings', ...)`.
- Update views/components to use the saved branding (logo, scanner headline/tagline, label name/tagline) and add a feature test `tests/Feature/InstallerTest.php` plus a reusable `installApplication()` helper in `tests/Pest.php`; register install routes in `routes/web.php` and add the migration `database/migrations/2026_03_23_000000_create_app_settings_table.php`.

### Testing
- Ran `git diff --check` and committed the changes successfully (commit id shown in repo), and performed `php -l` syntax checks against new and modified PHP files which reported no syntax errors.
- Added `tests/Feature/InstallerTest.php` and updated `tests/Pest.php` with an `installApplication()` helper and updated feature tests to call it in `beforeEach`; linting/parse checks for test files passed.
- Attempted full dependency install with `composer install` (and `--ignore-platform-req=php`); this environment prevented installing vendor packages because the container PHP is `8.5.3-dev` while the project requires `<8.4`, and outbound package downloads/clones from GitHub were blocked with HTTP 403, so the full Laravel test suite could not be executed here.
- Migration, new files, and view changes were added and committed; manual review and local syntax checks completed successfully but full automated runtime tests were blocked by the environment constraints described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c19f1be6a483279888c13c0b7b5ffa)