### PR TITLE
Add AY monogram header and AYOUNGCO company page

### DIFF
--- a/resources/views/company.blade.php
+++ b/resources/views/company.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        @include('partials.head', ['title' => 'AYOUNGCO, LLC'])
+    </head>
+    <body>
+        <main class="terminal-shell flex min-h-screen items-center">
+            <section class="terminal-panel w-full">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                    <div class="flex items-center gap-3">
+                        <span class="terminal-divider inline-flex h-16 w-16 items-center justify-center rounded-full border text-xl font-bold tracking-widest">
+                            AY
+                        </span>
+                        <p class="text-xs uppercase tracking-[0.3em] text-zinc-400">AYOUNGCO, LLC</p>
+                    </div>
+                    <a class="terminal-btn" href="{{ route('home') }}">Back to Main</a>
+                </div>
+
+                <h1 class="terminal-title mt-6">AYOUNGCO, LLC</h1>
+                <p class="terminal-muted mt-3 max-w-2xl">
+                    AYOUNGCO, LLC is the company page for Adam Young. This space can host company profile details, project highlights,
+                    and contact information.
+                </p>
+
+                <div class="mt-6 flex flex-wrap gap-2">
+                    <a class="terminal-btn terminal-btn-accent" href="mailto:hello@ayoungco.com">Contact</a>
+                    <a class="terminal-btn" href="{{ route('home') }}">Return Home</a>
+                </div>
+            </section>
+        </main>
+    </body>
+</html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,13 +1,21 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
-        @include('partials.head', ['title' => config('app.name')])
+        @include('partials.head', ['title' => 'Adam Young, digital architect, project manager'])
     </head>
     <body>
         <main class="terminal-shell flex min-h-screen items-center">
             <section class="terminal-panel w-full">
                 <div class="flex flex-wrap items-center justify-between gap-3">
-                    <img src="{{ app(\App\Support\SiteSettings::class)->logoUrl() }}" alt="{{ config('app.name') }}" class="logo-adaptive h-16 w-auto">
+                    <div class="flex items-center gap-3">
+                        <span class="terminal-divider inline-flex h-16 w-16 items-center justify-center rounded-full border text-xl font-bold tracking-widest">
+                            AY
+                        </span>
+                        <div>
+                            <p class="text-xs uppercase tracking-[0.3em] text-zinc-400">ayoungco @ main</p>
+                            <p class="text-sm text-zinc-300">Adam Young monogram</p>
+                        </div>
+                    </div>
                     <button type="button" data-theme-toggle class="terminal-btn terminal-btn-accent text-xs">Switch to Dark</button>
                 </div>
 
@@ -15,13 +23,14 @@
                     <p class="mt-6 border border-emerald-500 bg-emerald-950 p-3 text-emerald-300">{{ session('status') }}</p>
                 @endif
 
-                <h1 class="terminal-title mt-6">{{ $siteSettings['scanner_title'] }}</h1>
+                <h1 class="terminal-title mt-6">Adam Young, digital architect, project manager</h1>
                 <p class="terminal-muted mt-3 max-w-2xl">
                     {{ $siteSettings['scanner_tagline'] }}
                 </p>
 
                 <div class="mt-6 flex flex-wrap gap-2">
                     <a class="terminal-btn terminal-btn-accent" href="{{ route('login') }}">Log in</a>
+                    <a class="terminal-btn" href="{{ route('company') }}">AYOUNGCO, LLC</a>
                     @auth
                         <a class="terminal-btn" href="{{ url('/dashboard') }}">Dashboard</a>
                     @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,11 @@ Route::get('/', function () {
     return view('welcome');
 })->name('home');
 
+
+Route::get('/company', function () {
+    return view('company');
+})->name('company');
+
 Route::get('dashboard', function () {
     $items = Item::query()
         ->latest('created_at')


### PR DESCRIPTION
### Motivation
- Personalize the site landing header with an `AY` monogram and a concise label to reflect the individual/brand presence. 
- Provide a dedicated company page for AYOUNGCO to surface company information and a contact CTA.

### Description
- Replaced the logo area in `resources/views/welcome.blade.php` with an `AY` monogram block and the label `ayoungco @ main`, and set the page hero title to `Adam Young, digital architect, project manager`.
- Added a new view `resources/views/company.blade.php` that contains the company heading, short description, contact button, and a link back to the main page.
- Wired up a new route in `routes/web.php` at `/company` named `company` that returns the new `company` view.
- Added a navigation CTA on the main page linking to the new `route('company')`.

### Testing
- Ran `php artisan test`, which could not run in this environment because `vendor/autoload.php` is missing and dependencies are not installed (test run failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe52d08bc8327b0caf494041cec37)