### PR TITLE
Preserve scanned QR object destination throughout auth flow

### DIFF
--- a/app/Http/Controllers/Auth/PostLoginRedirectController.php
+++ b/app/Http/Controllers/Auth/PostLoginRedirectController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Support\AuthRedirect;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class PostLoginRedirectController extends Controller
+{
+    public function __invoke(Request $request): RedirectResponse
+    {
+        return redirect()->intended(AuthRedirect::resolveTarget($request));
+    }
+}

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,7 +15,9 @@ class VerifyEmailController extends Controller
      */
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
-        $fallback = AuthRedirect::resolveTarget($request).'?verified=1';
+        $target = AuthRedirect::resolveTarget($request);
+        $separator = str_contains($target, '?') ? '&' : '?';
+        $fallback = $target.$separator.'verified=1';
 
         if ($request->user()->hasVerifiedEmail()) {
             return redirect()->intended($fallback);

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Support\AuthRedirect;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
@@ -14,8 +15,10 @@ class VerifyEmailController extends Controller
      */
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
+        $fallback = AuthRedirect::resolveTarget($request).'?verified=1';
+
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+            return redirect()->intended($fallback);
         }
 
         if ($request->user()->markEmailAsVerified()) {
@@ -25,6 +28,6 @@ class VerifyEmailController extends Controller
             event(new Verified($user));
         }
 
-        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        return redirect()->intended($fallback);
     }
 }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -33,7 +33,7 @@ class ItemController extends Controller
             if (! $user) {
                 return view('items.missing-guest', [
                     'uuid' => $uuid,
-                    'loginUrl' => route('login', ['returnTo' => $returnToUrl], false),
+                    'loginUrl' => route('login', ['returnTo' => $returnToUrl], true),
                 ]);
             }
 
@@ -50,7 +50,7 @@ class ItemController extends Controller
                 'item' => $item,
                 'itemUrl' => $itemUrl,
                 'qrSvg' => $this->qrRenderer->renderSvg($itemUrl, 280),
-                'loginUrl' => route('login', ['returnTo' => $returnToUrl], false),
+                'loginUrl' => route('login', ['returnTo' => $returnToUrl], true),
             ]);
         }
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -7,6 +7,7 @@ use App\Models\ItemEvent;
 use App\Services\ImageCompressionService;
 use App\Services\QrCodeRenderService;
 use App\Services\QrVerificationService;
+use App\Support\AuthRedirect;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -21,6 +22,7 @@ class ItemController extends Controller
 
     public function show(Request $request, string $uuid): View
     {
+        $returnToUrl = AuthRedirect::rememberScannedItemUrl($request, $uuid);
         $user = $request->user();
         $item = Item::query()
             ->where('uuid', $uuid)
@@ -31,6 +33,7 @@ class ItemController extends Controller
             if (! $user) {
                 return view('items.missing-guest', [
                     'uuid' => $uuid,
+                    'loginUrl' => route('login', ['returnTo' => $returnToUrl], false),
                 ]);
             }
 
@@ -47,6 +50,7 @@ class ItemController extends Controller
                 'item' => $item,
                 'itemUrl' => $itemUrl,
                 'qrSvg' => $this->qrRenderer->renderSvg($itemUrl, 280),
+                'loginUrl' => route('login', ['returnTo' => $returnToUrl], false),
             ]);
         }
 

--- a/app/Http/Middleware/EnsureEmailIsVerifiedForActions.php
+++ b/app/Http/Middleware/EnsureEmailIsVerifiedForActions.php
@@ -21,7 +21,7 @@ class EnsureEmailIsVerifiedForActions
         if (! $user) {
             return redirect()->guest(route('login', [
                 'returnTo' => AuthRedirect::resolveTarget($request),
-            ], false));
+            ], true));
         }
 
         if (! $user->email_verified_at) {

--- a/app/Http/Middleware/EnsureEmailIsVerifiedForActions.php
+++ b/app/Http/Middleware/EnsureEmailIsVerifiedForActions.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Support\AuthRedirect;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,7 +19,9 @@ class EnsureEmailIsVerifiedForActions
         $user = $request->user();
 
         if (! $user) {
-            return redirect()->guest('/login');
+            return redirect()->guest(route('login', [
+                'returnTo' => AuthRedirect::resolveTarget($request),
+            ], false));
         }
 
         if (! $user->email_verified_at) {

--- a/app/Http/Middleware/EnsureVerifiedEmail.php
+++ b/app/Http/Middleware/EnsureVerifiedEmail.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Support\AuthRedirect;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,7 +14,9 @@ class EnsureVerifiedEmail
         $user = $request->user();
 
         if (! $user) {
-            return redirect()->guest(route('login'));
+            return redirect()->guest(route('login', [
+                'returnTo' => AuthRedirect::resolveTarget($request),
+            ], false));
         }
 
         if (! $user->email_verified_at) {

--- a/app/Http/Middleware/EnsureVerifiedEmail.php
+++ b/app/Http/Middleware/EnsureVerifiedEmail.php
@@ -16,7 +16,7 @@ class EnsureVerifiedEmail
         if (! $user) {
             return redirect()->guest(route('login', [
                 'returnTo' => AuthRedirect::resolveTarget($request),
-            ], false));
+            ], true));
         }
 
         if (! $user->email_verified_at) {

--- a/app/Support/AuthRedirect.php
+++ b/app/Support/AuthRedirect.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+
+class AuthRedirect
+{
+    public const SCANNED_ITEM_URL_SESSION_KEY = 'auth.scanned_item_url';
+
+    public static function rememberScannedItemUrl(Request $request, string $uuid): string
+    {
+        $targetUrl = route('items.show', ['uuid' => $uuid], false);
+
+        $request->session()->put(self::SCANNED_ITEM_URL_SESSION_KEY, $targetUrl);
+
+        return $targetUrl;
+    }
+
+    public static function resolveTarget(Request $request, string $fallbackRoute = 'dashboard'): string
+    {
+        $targetUrl = $request->session()->get(self::SCANNED_ITEM_URL_SESSION_KEY);
+
+        if (is_string($targetUrl) && $targetUrl !== '') {
+            return $targetUrl;
+        }
+
+        return route($fallbackRoute, absolute: false);
+    }
+}

--- a/app/Support/AuthRedirect.php
+++ b/app/Support/AuthRedirect.php
@@ -10,7 +10,7 @@ class AuthRedirect
 
     public static function rememberScannedItemUrl(Request $request, string $uuid): string
     {
-        $targetUrl = route('items.show', ['uuid' => $uuid], false);
+        $targetUrl = route('items.show', ['uuid' => $uuid], true);
 
         $request->session()->put(self::SCANNED_ITEM_URL_SESSION_KEY, $targetUrl);
 
@@ -25,6 +25,6 @@ class AuthRedirect
             return $targetUrl;
         }
 
-        return route($fallbackRoute, absolute: false);
+        return route($fallbackRoute, absolute: true);
     }
 }

--- a/config/auth0.php
+++ b/config/auth0.php
@@ -60,7 +60,7 @@ return Configuration::VERSION_2 + [
         Configuration::CONFIG_ROUTE_INDEX => Configuration::get(Configuration::CONFIG_ROUTE_INDEX, '/'),
         Configuration::CONFIG_ROUTE_CALLBACK => Configuration::get(Configuration::CONFIG_ROUTE_CALLBACK, '/callback'),
         Configuration::CONFIG_ROUTE_LOGIN => Configuration::get(Configuration::CONFIG_ROUTE_LOGIN, '/login'),
-        Configuration::CONFIG_ROUTE_AFTER_LOGIN => Configuration::get(Configuration::CONFIG_ROUTE_AFTER_LOGIN, '/dashboard'),
+        Configuration::CONFIG_ROUTE_AFTER_LOGIN => Configuration::get(Configuration::CONFIG_ROUTE_AFTER_LOGIN, '/auth/redirect'),
         Configuration::CONFIG_ROUTE_LOGOUT => Configuration::get(Configuration::CONFIG_ROUTE_LOGOUT, '/logout'),
         Configuration::CONFIG_ROUTE_AFTER_LOGOUT => Configuration::get(Configuration::CONFIG_ROUTE_AFTER_LOGOUT, '/'),
     ],

--- a/resources/views/items/missing-guest.blade.php
+++ b/resources/views/items/missing-guest.blade.php
@@ -13,7 +13,7 @@
             <p class="terminal-accent">[SCAN TARGET: {{ $uuid }}]</p>
             <h1 class="terminal-title mt-2">Object Not Initialized</h1>
             <p class="terminal-muted mt-3">This UUID is unclaimed. {{ $siteSettings['scanner_tagline'] }}</p>
-            <a href="/login" class="terminal-btn terminal-btn-accent mt-4">Login With Auth0</a>
+            <a href="{{ $loginUrl }}" class="terminal-btn terminal-btn-accent mt-4">Login With Auth0</a>
         </section>
     </main>
 </body>

--- a/resources/views/items/public.blade.php
+++ b/resources/views/items/public.blade.php
@@ -34,6 +34,7 @@
             </div>
 
             <p class="terminal-muted mt-3">Public view. Log in for full timeline media and posting controls.</p>
+            <a href="{{ $loginUrl }}" class="terminal-btn terminal-btn-accent mt-4">Login With Auth0</a>
 
             <div class="mt-6">
                 <h2 class="terminal-accent text-base font-semibold">Timeline</h2>

--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\AuthRedirect;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Layout;
@@ -28,7 +29,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         session(['auth.password_confirmed_at' => time()]);
 
-        $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(default: AuthRedirect::resolveTarget(request()), navigate: true);
     }
 }; ?>
 

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -128,7 +128,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     </div>
 
     <div>
-        <a href="{{ route('login', ['returnTo' => \App\Support\AuthRedirect::resolveTarget(request())], false) }}">
+        <a href="{{ route('login', ['returnTo' => AuthRedirect::resolveTarget(request())], true) }}">
             <flux:button variant="secondary" class="w-full">{{ __('Continue with Auth0') }}</flux:button>
         </a>
     </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\AuthRedirect;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
@@ -40,7 +41,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         RateLimiter::clear($this->throttleKey());
         Session::regenerate();
 
-        $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(default: AuthRedirect::resolveTarget(request()), navigate: true);
     }
 
     /**
@@ -127,7 +128,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     </div>
 
     <div>
-        <a href="/login">
+        <a href="{{ route('login', ['returnTo' => \App\Support\AuthRedirect::resolveTarget(request())], false) }}">
             <flux:button variant="secondary" class="w-full">{{ __('Continue with Auth0') }}</flux:button>
         </a>
     </div>

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\AuthRedirect;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Auth;
@@ -31,7 +32,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         Auth::login($user);
 
-        $this->redirectIntended(route('dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(AuthRedirect::resolveTarget(request()), navigate: true);
     }
 }; ?>
 

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Livewire\Actions\Logout;
+use App\Support\AuthRedirect;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Livewire\Attributes\Layout;
@@ -13,7 +14,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     public function sendVerification(): void
     {
         if (Auth::user()->hasVerifiedEmail()) {
-            $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
+            $this->redirectIntended(default: AuthRedirect::resolveTarget(request()), navigate: true);
 
             return;
         }

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ItemController;
 use App\Http\Controllers\SiteSettingsController;
+use App\Http\Controllers\Auth\PostLoginRedirectController;
 use App\Models\Item;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
@@ -9,6 +10,10 @@ use Livewire\Volt\Volt;
 Route::get('/', function () {
     return view('welcome');
 })->name('home');
+
+Route::get('auth/redirect', PostLoginRedirectController::class)
+    ->middleware(['auth'])
+    ->name('auth.redirect');
 
 Route::get('dashboard', function () {
     $items = Item::query()

--- a/tests/Feature/ItemFlowTest.php
+++ b/tests/Feature/ItemFlowTest.php
@@ -12,12 +12,15 @@ beforeEach(function () {
 
 test('guest sees login prompt for unknown uuid', function () {
     $uuid = (string) Str::uuid();
+    $expectedReturnTo = route('items.show', ['uuid' => $uuid], false);
 
     $response = $this->get('/'.$uuid);
 
     $response->assertOk();
     $response->assertSee('Object Not Initialized');
     $response->assertSee('Login With Auth0');
+    $response->assertSee(route('login', ['returnTo' => $expectedReturnTo], false), false);
+    $response->assertSessionHas('auth.scanned_item_url', $expectedReturnTo);
 });
 
 test('guest sees condensed timeline without inline images', function () {

--- a/tests/Feature/ItemFlowTest.php
+++ b/tests/Feature/ItemFlowTest.php
@@ -12,14 +12,14 @@ beforeEach(function () {
 
 test('guest sees login prompt for unknown uuid', function () {
     $uuid = (string) Str::uuid();
-    $expectedReturnTo = route('items.show', ['uuid' => $uuid], false);
+    $expectedReturnTo = route('items.show', ['uuid' => $uuid], true);
 
     $response = $this->get('/'.$uuid);
 
     $response->assertOk();
     $response->assertSee('Object Not Initialized');
     $response->assertSee('Login With Auth0');
-    $response->assertSee(route('login', ['returnTo' => $expectedReturnTo], false), false);
+    $response->assertSee(route('login', ['returnTo' => $expectedReturnTo], true), false);
     $response->assertSessionHas('auth.scanned_item_url', $expectedReturnTo);
 });
 


### PR DESCRIPTION
### Motivation
- Ensure users who scan a QR code are returned to the exact object page they scanned after completing any auth flows (login, register, email verify, confirm password). 
- Avoid losing scan context when the app redirects through Auth0 or local auth pages so UX for camera-driven workflows is seamless.

### Description
- Add `App\Support\AuthRedirect` to persist a scanned item URL in session and resolve the preferred auth redirect target (fallback to `dashboard`).
- Record the scanned item target on every `/{uuid}` visit in `ItemController::show` and expose `loginUrl` to guest item views so login links include `returnTo` that points back to the scanned object.
- Update middleware and auth controllers (email verification, confirm-password, local login/register, and verified-email middleware) to resolve redirect destinations via `AuthRedirect` so post-auth navigation returns to the scanned object when present.
- Add a `/auth/redirect` endpoint (`PostLoginRedirectController`) and switch Auth0 `after_login` to `/auth/redirect` so Auth0 SDK logins also respect the stored scanned target.
- Update `tests/Feature/ItemFlowTest.php` to assert the login link includes the expected `returnTo` target and that the scanned target is saved in session.

### Testing
- Ran `php artisan test tests/Feature/ItemFlowTest.php`; test execution failed in this environment due to missing dependencies (`vendor/autoload.php` not found).
- Static checks and repository operations performed (files added/committed) and feature test updated locally in the branch; no passing automated test run available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb61892748327ae2ccfdef1ca2c2e)