### PR TITLE
Add rapid dashboard search and sidebar model links

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -15,6 +15,13 @@
                 <flux:navlist.group :heading="__('Platform')" class="grid">
                     <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard') }}</flux:navlist.item>
                 </flux:navlist.group>
+
+                <flux:navlist.group :heading="__('Models')" class="grid">
+                    <flux:navlist.item icon="cube" :href="route('things.index')" :current="request()->routeIs('things.*')" wire:navigate>{{ __('Things') }}</flux:navlist.item>
+                    <flux:navlist.item icon="tag" :href="route('properties.index')" :current="request()->routeIs('properties.*')" wire:navigate>{{ __('Properties') }}</flux:navlist.item>
+                    <flux:navlist.item icon="link" :href="route('relations.index')" :current="request()->routeIs('relations.*')" wire:navigate>{{ __('Relations') }}</flux:navlist.item>
+                    <flux:navlist.item icon="chat-bubble-left-right" :href="route('messages.index')" :current="request()->routeIs('messages.*')" wire:navigate>{{ __('Messages') }}</flux:navlist.item>
+                </flux:navlist.group>
             </flux:navlist>
 
             <flux:spacer />

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,5 +1,5 @@
 <x-layouts.app :title="__('Dashboard')">
-    <section class="terminal-shell">
+    <section class="terminal-shell space-y-4">
         <div class="terminal-panel">
             <div class="terminal-divider border-b px-4 py-3">
                 <h2 class="terminal-muted text-sm font-semibold uppercase tracking-[0.2em]">
@@ -7,9 +7,38 @@
                 </h2>
             </div>
 
+            <form method="GET" action="{{ route('dashboard') }}" class="terminal-divider border-b px-4 py-3">
+                <label for="item-search" class="terminal-muted mb-2 block text-xs font-semibold uppercase tracking-[0.2em]">
+                    Rapid Full Text Search
+                </label>
+                <div class="flex gap-2">
+                    <input
+                        id="item-search"
+                        name="q"
+                        type="search"
+                        value="{{ $search }}"
+                        placeholder="Search item names and descriptions"
+                        class="terminal-divider w-full rounded-md border bg-transparent px-3 py-2 text-sm"
+                        autocomplete="off"
+                    >
+                    <button type="submit" class="terminal-divider rounded-md border px-3 py-2 text-sm">
+                        Search
+                    </button>
+                    @if($search !== '')
+                        <a href="{{ route('dashboard') }}" class="terminal-divider rounded-md border px-3 py-2 text-sm">
+                            Clear
+                        </a>
+                    @endif
+                </div>
+            </form>
+
             @if($items->isEmpty())
                 <div class="terminal-muted px-4 py-6 text-sm">
-                    No objects yet.
+                    @if($search !== '')
+                        No objects matched "{{ $search }}".
+                    @else
+                        No objects yet.
+                    @endif
                 </div>
             @else
                 <ul class="terminal-divider divide-y">
@@ -21,6 +50,11 @@
                             >
                                 {{ $item->name }}
                             </a>
+                            @if(!empty($item->description))
+                                <p class="terminal-muted mt-1 text-xs">
+                                    {{ $item->description }}
+                                </p>
+                            @endif
                         </li>
                     @endforeach
                 </ul>

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -1,0 +1,7 @@
+<x-layouts.app :title="__('Messages')">
+    <section class="terminal-shell">
+        <div class="terminal-panel p-4">
+            <p class="terminal-muted text-sm">Message records are available here.</p>
+        </div>
+    </section>
+</x-layouts.app>

--- a/resources/views/properties/index.blade.php
+++ b/resources/views/properties/index.blade.php
@@ -1,0 +1,7 @@
+<x-layouts.app :title="__('Properties')">
+    <section class="terminal-shell">
+        <div class="terminal-panel p-4">
+            <p class="terminal-muted text-sm">Property records are available here.</p>
+        </div>
+    </section>
+</x-layouts.app>

--- a/resources/views/relations/index.blade.php
+++ b/resources/views/relations/index.blade.php
@@ -1,0 +1,7 @@
+<x-layouts.app :title="__('Relations')">
+    <section class="terminal-shell">
+        <div class="terminal-panel p-4">
+            <p class="terminal-muted text-sm">Relation records are available here.</p>
+        </div>
+    </section>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,13 @@
 <?php
 
 use App\Http\Controllers\ItemController;
+use App\Http\Controllers\MessageController;
+use App\Http\Controllers\PropertyController;
+use App\Http\Controllers\RelationController;
 use App\Http\Controllers\SiteSettingsController;
+use App\Http\Controllers\ThingController;
 use App\Models\Item;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 
@@ -11,11 +16,29 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('dashboard', function () {
-    $items = Item::query()
-        ->latest('created_at')
-        ->get();
+    $search = trim((string) request()->query('q', ''));
 
-    return view('dashboard', compact('items'));
+    $items = Item::query()
+        ->when($search !== '', function (Builder $query) use ($search) {
+            $driver = $query->getConnection()->getDriverName();
+
+            if (in_array($driver, ['mysql', 'pgsql'], true)) {
+                $query->whereFullText(['name', 'description'], $search);
+
+                return;
+            }
+
+            $query->where(function (Builder $likeQuery) use ($search) {
+                $likeQuery
+                    ->where('name', 'like', "%{$search}%")
+                    ->orWhere('description', 'like', "%{$search}%");
+            });
+        })
+        ->latest('created_at')
+        ->limit(100)
+        ->get(['id', 'uuid', 'name', 'description', 'created_at']);
+
+    return view('dashboard', compact('items', 'search'));
 })
     ->middleware(['auth'])
     ->name('dashboard');
@@ -28,6 +51,11 @@ Route::middleware(['auth'])->group(function () {
     Volt::route('settings/appearance', 'settings.appearance')->name('settings.appearance');
     Route::get('settings/site', [SiteSettingsController::class, 'edit'])->name('settings.site');
     Route::put('settings/site', [SiteSettingsController::class, 'update'])->name('settings.site.update');
+
+    Route::resource('things', ThingController::class)->only(['index']);
+    Route::resource('properties', PropertyController::class)->only(['index']);
+    Route::resource('relations', RelationController::class)->only(['index']);
+    Route::resource('messages', MessageController::class)->only(['index']);
 });
 
 require __DIR__.'/auth.php';
@@ -48,6 +76,10 @@ Route::post('/{uuid}/events', [ItemController::class, 'addPhoto'])
     ->whereUuid('uuid')
     ->middleware(['auth0.authenticate', 'auth0.verified'])
     ->name('items.events.store');
+
+Route::get('/{slug}', [ThingController::class, 'showBySlug'])
+    ->where('slug', '^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$)(?!dashboard$|settings$|things$|properties$|relations$|messages$)[A-Za-z0-9\-\._~%]+$')
+    ->name('things.show-by-slug');
 
 Route::get('/{uuid}', [ItemController::class, 'show'])
     ->whereUuid('uuid')


### PR DESCRIPTION
### Motivation
- Provide a fast, lightweight way to search items from the authenticated dashboard and keep dashboard payloads small for faster page loads. 
- Expose first-class model entry points in the main navigation so users can reach `Things`, `Properties`, `Relations`, and `Messages` quickly. 

### Description
- Added a DB-driver-aware rapid full-text search on the dashboard route using a `q` query param with `whereFullText` for MySQL/Postgres and a `LIKE` fallback for other drivers, limited results to the latest 100 rows, and selected only key columns (`id`, `uuid`, `name`, `description`, `created_at`) in `routes/web.php`. 
- Updated the dashboard view (`resources/views/dashboard.blade.php`) with a compact search form, search/clear controls, and query-aware no-results messaging. 
- Added a new `Models` nav group in the sidebar (`resources/views/components/layouts/app/sidebar.blade.php`) with links to `things.index`, `properties.index`, `relations.index`, and `messages.index`. 
- Registered authenticated index routes for the model sections and added lightweight placeholder index views for `Properties`, `Relations`, and `Messages` so the new links resolve, and adjusted the public thing slug route to avoid colliding with UUIDs. 

### Testing
- Ran PHP syntax checks: `php -l routes/web.php` succeeded and `php -l resources/views/dashboard.blade.php` succeeded. 
- Attempted `php artisan route:list --path=dashboard --path=things --path=properties --path=relations --path=messages`, which could not run in this environment due to missing Composer dependencies (`vendor/autoload.php`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeac46d2b0832787d583f777a3d214)